### PR TITLE
Including CachyOS os-release file

### DIFF
--- a/cachyos
+++ b/cachyos
@@ -1,0 +1,11 @@
+NAME="CachyOS Linux"
+PRETTY_NAME="CachyOS"
+ID=cachyos
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://cachyos.org/"
+DOCUMENTATION_URL="https://wiki.cachyos.org/"
+SUPPORT_URL="https://discuss.cachyos.org/"
+BUG_REPORT_URL="https://github.com/cachyos"
+PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
+LOGO=cachyos


### PR DESCRIPTION
I'm just including the CachyOs Linux **os-release** file :)

Got it directly from my `/etc/os-release` file.